### PR TITLE
Fix duplicate site name in home page title

### DIFF
--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -14,12 +14,13 @@ type Props = {
 
 const { title, description, ogData } = Astro.props;
 const plainTitle = stripMarkdown(title);
+const pageTitle = plainTitle === SITE.NAME ? plainTitle : `${plainTitle} | ${SITE.NAME}`;
 ---
 
 <!doctype html>
 <html lang="en">
   <head>
-    <Head title={`${plainTitle} | ${SITE.NAME}`} description={description} ogData={ogData} />
+    <Head title={pageTitle} description={description} ogData={ogData} />
   </head>
   <body>
     <a href="#main-content" class="skip-link">Skip to main content</a>


### PR DESCRIPTION
## Summary
- Skip appending `| Dispatches` suffix when the page title already equals the site name
- Fixes the home page rendering as "Dispatches | Dispatches" in the browser tab

## Test plan
- [ ] Verify home page title is just "Dispatches"
- [ ] Verify other pages still show "Page Title | Dispatches"

🤖 Generated with [Claude Code](https://claude.com/claude-code)