### PR TITLE
Add about page and navigation link

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -46,6 +46,17 @@ const currentPath = Astro.url?.pathname ?? "/";
               projects
             </Link>
           </li>
+          <li aria-hidden="true" class="text-black/40 dark:text-white/40">
+            /
+          </li>
+          <li>
+            <Link
+              href="/about"
+              aria-current={currentPath.startsWith("/about") ? "page" : undefined}
+            >
+              about
+            </Link>
+          </li>
         </ul>
       </nav>
     </div>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,0 +1,54 @@
+---
+import PageLayout from "@layouts/PageLayout.astro";
+import Container from "@components/Container.astro";
+import Link from "@components/Link.astro";
+import { SITE, SOCIALS } from "@consts";
+import { getHomeOGData } from "@lib/opengraph";
+
+const ogData = getHomeOGData(
+  Astro.url.toString(),
+  Astro.site?.toString() || ""
+);
+---
+
+<PageLayout title="About" description="About Dispatches and its author" ogData={ogData}>
+  <Container>
+    <div class="space-y-10">
+      <h1 class="animate font-semibold text-black dark:text-white">
+        About
+      </h1>
+
+      <div class="space-y-4">
+        <section class="animate space-y-4">
+          <h2 class="font-semibold text-black dark:text-white">About Dispatches</h2>
+          <article class="prose dark:prose-invert">
+            <p>
+              <em>Dispatches</em> is where I publish technical writing on topics of personal interest.
+              During this initial phase, much of the content will be "refurbished-and-expanded": older
+              personal notes or explanations, updated and expanded where necessary.
+            </p>
+            <p>
+              Expect a focus on Swift, lower-level iOS work, and—as of late—agentic coding assistants.
+            </p>
+          </article>
+        </section>
+
+        <section class="animate space-y-4">
+          <h2 class="font-semibold text-black dark:text-white">Connect</h2>
+          <article>
+            <p class="mb-4">Feel free to reach out:</p>
+            <ul class="flex flex-wrap gap-2">
+              {SOCIALS.map(SOCIAL => (
+                <li class="flex gap-x-2 text-nowrap">
+                  <Link href={SOCIAL.HREF} external aria-label={`${SITE.NAME} on ${SOCIAL.NAME}`}>
+                    {SOCIAL.NAME}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </article>
+        </section>
+      </div>
+    </div>
+  </Container>
+</PageLayout>


### PR DESCRIPTION
## Summary
- Add `/about` page with site description and social links
- Add "about" entry to header navigation, following existing a11y patterns (`aria-current`, semantic list items)

## Notes
The about page content is minimal — site description + connect links. You'll likely want to personalize the bio section.

## Test plan
- [ ] Verify `/about` page loads and renders correctly
- [ ] Verify navigation shows "about" link on all pages
- [ ] Verify `aria-current="page"` activates on `/about`

🤖 Generated with [Claude Code](https://claude.com/claude-code)