### PR TITLE
Upgrade cspell to v10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: '>=22.18.0'
           cache: 'npm'
 
       - name: Setup Rust

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
 
       - name: Setup Rust

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "@cspell/dict-npm": "^5.2.38",
         "@cspell/dict-typescript": "^3.2.3",
         "@playwright/test": "^1.59.1",
-        "cspell": "^9.8.0",
+        "cspell": "^10.0.0",
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "markdownlint-cli2": "^0.22.0",
         "prettier": "^3.8.3"
@@ -600,9 +600,9 @@
       }
     },
     "node_modules/@cspell/cspell-bundled-dicts": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-9.8.0.tgz",
-      "integrity": "sha512-MpXFpVyBPfJQ1YuVotljqUaGf6lWuf+fuWBBgs0PHFYTSjRPWuIxviAaCDnup/CJLLH60xQL4IlcQe4TOjzljw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-10.0.0.tgz",
+      "integrity": "sha512-ci410HEkng2582oOjlRHQtlGXwh+rUC/mVcN9dObLHpKhvPgzn2S6vT56pARstxxZpcCUG/oLhn3dCqdJlVzmA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -667,86 +667,86 @@
         "@cspell/dict-zig": "^1.0.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/@cspell/cspell-json-reporter": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-9.8.0.tgz",
-      "integrity": "sha512-nqUaSo9T7l8KrE22gc7ZIs+zvP7ak1i7JqGdRs8sGvh2Ijqj43qYQLePgb1b/vm8a1bavnc51m+vf05hpd3g3Q==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-10.0.0.tgz",
+      "integrity": "sha512-hq5dui2ngYMZKbBauX7K1tkqlu81sX/uaCO49ZJLPjeZsE1auZLtHehDLfAr/ZXoj/dLYeQMSKiaJyE+qLVPHA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-types": "9.8.0"
+        "@cspell/cspell-types": "10.0.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/@cspell/cspell-performance-monitor": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-performance-monitor/-/cspell-performance-monitor-9.8.0.tgz",
-      "integrity": "sha512-IsrXYzn23yJICIQ915ACdf+2lNEcFNTu5BIQt3khHOsGVvZ9/AZYpu9Dk825vUyZG7RHg2Oi6dYNiJtULG4ouQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-performance-monitor/-/cspell-performance-monitor-10.0.0.tgz",
+      "integrity": "sha512-2vMh2pLt2dg/ArYvWjMP4v9HCm0pRhONsEJyc8oHdZyOYvX7trixX894I0M39+VBf3yWtPCEgYRh1UDXNIZRig==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20.18"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/@cspell/cspell-pipe": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-9.8.0.tgz",
-      "integrity": "sha512-ISEUD8PHYkd2Ktafc6hFfIXdGKYUvthA09NbwwZsWmOqYyk4wWKHZKqyyxD+BcrFwOyMOJcD8OEvIjkRQp2SJw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-10.0.0.tgz",
+      "integrity": "sha512-qcgHhQvtEX8LSwIVsWrdUgiGim52lN3jT+ghlkdp72v+nBcGKsS2frEKTmbGLug+xcqppkzs6Q6VmsFp1MGtfA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/@cspell/cspell-resolver": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-9.8.0.tgz",
-      "integrity": "sha512-PZJj56BZpKfMxOzWkyt7b+aIXObe+8Ku/zLI4xDXPSuQPENbHBFHfPIZx68CyGEkanKxZ1ewKVx/FT1FUy+wDA==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-10.0.0.tgz",
+      "integrity": "sha512-8H+IUDB7SmrpcRugQ5f55qG81ZShk6nQRk+natLz41TEY98D8/LCmjHEkh/vhDPph9pVJmNUp7JcM2E1UHEa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "global-directory": "^5.0.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/@cspell/cspell-service-bus": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-9.8.0.tgz",
-      "integrity": "sha512-P45sd2nqwcqhulBBbQnZB/JNcobecTrP4Ky3vmEq0cprsvavc+ZoHF9U2Ql5ghMSUzjrF2n1aNzZ8cH4IlsnKg==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-10.0.0.tgz",
+      "integrity": "sha512-V7eigqg/TOoKwNK4Q18wr9KGxA8U5SFcoWVS8RyAxv4mQ+yNKHhvHEbRBifjPbQDer66afOrclb2UbqkIy2SOw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/@cspell/cspell-types": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-9.8.0.tgz",
-      "integrity": "sha512-7Ge4UD6SCA49Tcc3+GTlz3Xn4cqVUAXtDO0u9IeHvJgkN3Me2Rw2GB/CtGmhKST3YeEeZMX7ww09TdHMUJlehw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-10.0.0.tgz",
+      "integrity": "sha512-IQA++Idqb8fZzkCbHq3+T+9yG9WpeaBxomOrG2KcR/Pj0CgnovzuApYKL2cc35UWLePboKinMeqEPiweFpHVug==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/@cspell/cspell-worker": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-worker/-/cspell-worker-9.8.0.tgz",
-      "integrity": "sha512-W8FLdE3MXPLbWtAXciILQhk9CHd6Mt+HRjZHM8m+dwE1Bc2TAjUai8kIxsdhHUq58p7gYY2ekr5sg1uYOUgTAA==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-worker/-/cspell-worker-10.0.0.tgz",
+      "integrity": "sha512-V5bjMldNksilnja3fu8muQmkW5/guyua1yNVOhoE2r7othSvjuDlGMl8g2bQSrWjp+UXu0dP/BEZ6JC/IfNwTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cspell-lib": "9.8.0"
+        "cspell-lib": "10.0.0"
       },
       "engines": {
-        "node": ">=20.18"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/@cspell/dict-ada": {
@@ -1175,57 +1175,57 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dynamic-import": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-9.8.0.tgz",
-      "integrity": "sha512-wMgb32lqG9g6lCipUQsY9Bk5idXPDz7wvzOqEsU1M2HmNYmdE1wfPoRpfQfsVL965iG3+6h8QLr2+8FKpweFEQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-10.0.0.tgz",
+      "integrity": "sha512-fMqu/5Ma1Q5ZCR/Par+Q4pvaTKmx5pKZzQmkwld2hNounVdk2OaIPM9MzpNn6I1mLk5J+wTnIZmfcWNAzNP9aQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/url": "9.8.0",
+        "@cspell/url": "10.0.0",
         "import-meta-resolve": "^4.2.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/@cspell/filetypes": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/@cspell/filetypes/-/filetypes-9.8.0.tgz",
-      "integrity": "sha512-yHvtYn9qt6zykua77sNzTcf7HrG/dpo/+2pCMGSrfSrQypSNT6FUFvMS04W7kwhP86U1GkCjppNykXuoH3cqug==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/filetypes/-/filetypes-10.0.0.tgz",
+      "integrity": "sha512-UP57j9yrDtlCHpFxc/eGho1m8DP5olfu9KRWwd5fiqL9nMSE2rUJtPzQyvqmDwO5bVZt3B+fTVdo4gxuiqw25A==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/@cspell/rpc": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/@cspell/rpc/-/rpc-9.8.0.tgz",
-      "integrity": "sha512-t4lHEa254W+PePXNQ1noW7QhQxz/mhsJ9X8LEt0ILzBbPWCJzN+JuaM7EiolIPiwxtfxpMwKx9482kt4eTja7A==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/rpc/-/rpc-10.0.0.tgz",
+      "integrity": "sha512-QrpOZMwz2pAjvl6Hky2PauYoMpLCASn3osjn7uKUbgFV70sahyj6tmx4rRgRX7vHu2WQLZev+YsuO4EujiBDOg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20.18"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/@cspell/strong-weak-map": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-9.8.0.tgz",
-      "integrity": "sha512-HocksAqZ0JcWA5oWO7TIlOCftXVGkPGzbeFlCRRrjJpZmYQH+4NdeEXyQC6T89NGocp45td/CgyBcAaFMy1N9w==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-10.0.0.tgz",
+      "integrity": "sha512-JRsato0s2IjYdsng+AGL6oAqgZVQgih5aWKdmxs21H6EdhMaoFDmRE5kXm/RT5a6OMdtnzQM9DqeToqBChWIOQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/@cspell/url": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-9.8.0.tgz",
-      "integrity": "sha512-LY1lFiZLTQF/ma1ilfKmRmFmEOw0RfYhyl0UMhY7/d93b+kiDMhxP/9Qir4+5LyiRncaE3++ZcWno9Hya+ssRg==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-10.0.0.tgz",
+      "integrity": "sha512-q+0pHQ8DbqjemyaOn/mTtBRbCuKDqhnsVbZ6J9zkTsxPgMpccjy0s5oLXwomfrrxMRBH+UcbERwtUmE+SbnoIQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/@ctrl/tinycolor": {
@@ -4902,23 +4902,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/clear-module": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/clear-module/-/clear-module-4.1.2.tgz",
-      "integrity": "sha512-LWAxzHqdHsAZlPlEyJ2Poz6AIs384mPeqLVCru2p0BrP9G/kVGuhNyZYClLO6cXlnuJjzC8xtsJIuMjKqLXoAw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "parent-module": "^2.0.0",
-        "resolve-from": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/cli-boxes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
@@ -5156,29 +5139,29 @@
       }
     },
     "node_modules/cspell": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/cspell/-/cspell-9.8.0.tgz",
-      "integrity": "sha512-qL0VErMSn8BDxaPxcV+9uenffgjPS+5Jfz+m4rCsvYjzLwr7AaaJBWWSV2UiAe/4cturae8n8qzxiGnbbazkRw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cspell/-/cspell-10.0.0.tgz",
+      "integrity": "sha512-R25gsSR1SLlcGyw48fwJwp0PjXrVdl7RDO/Dm5+s4DvC1uQSlyiUxsr/8ZtbyC/MPeUJFQN9B4luqLlSm0WelQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-json-reporter": "9.8.0",
-        "@cspell/cspell-performance-monitor": "9.8.0",
-        "@cspell/cspell-pipe": "9.8.0",
-        "@cspell/cspell-types": "9.8.0",
-        "@cspell/cspell-worker": "9.8.0",
-        "@cspell/dynamic-import": "9.8.0",
-        "@cspell/url": "9.8.0",
+        "@cspell/cspell-json-reporter": "10.0.0",
+        "@cspell/cspell-performance-monitor": "10.0.0",
+        "@cspell/cspell-pipe": "10.0.0",
+        "@cspell/cspell-types": "10.0.0",
+        "@cspell/cspell-worker": "10.0.0",
+        "@cspell/dynamic-import": "10.0.0",
+        "@cspell/url": "10.0.0",
         "ansi-regex": "^6.2.2",
         "chalk": "^5.6.2",
         "chalk-template": "^1.1.2",
         "commander": "^14.0.3",
-        "cspell-config-lib": "9.8.0",
-        "cspell-dictionary": "9.8.0",
-        "cspell-gitignore": "9.8.0",
-        "cspell-glob": "9.8.0",
-        "cspell-io": "9.8.0",
-        "cspell-lib": "9.8.0",
+        "cspell-config-lib": "10.0.0",
+        "cspell-dictionary": "10.0.0",
+        "cspell-gitignore": "10.0.0",
+        "cspell-glob": "10.0.0",
+        "cspell-io": "10.0.0",
+        "cspell-lib": "10.0.0",
         "fast-json-stable-stringify": "^2.1.0",
         "flatted": "^3.4.2",
         "semver": "^7.7.4",
@@ -5189,155 +5172,167 @@
         "cspell-esm": "bin.mjs"
       },
       "engines": {
-        "node": ">=20.18"
+        "node": ">=22.18.0"
       },
       "funding": {
         "url": "https://github.com/streetsidesoftware/cspell?sponsor=1"
       }
     },
     "node_modules/cspell-config-lib": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-9.8.0.tgz",
-      "integrity": "sha512-gMJBAgYPvvO+uDFLUcGWaTu6/e+r8mm4GD4rQfWa/yV4F9fj+yOYLIMZqLWRvT1moHZX1FxyVvUbJcmZ1gfebg==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-10.0.0.tgz",
+      "integrity": "sha512-HWK7SRnJ3N/kOThw/uzmXmQYCzBxu58Jkq2hHyte1voDl118BeNFoaNRWMpYdHbBi3kCj8gaZu8wGtm+Zmdhxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-types": "9.8.0",
+        "@cspell/cspell-types": "10.0.0",
         "comment-json": "^4.6.2",
         "smol-toml": "^1.6.1",
         "yaml": "^2.8.3"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/cspell-dictionary": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-9.8.0.tgz",
-      "integrity": "sha512-QW4hdkWcrxZA1QNqi26U0S/U3/V+tKCm7JaaesEJW2F6Ao+23AbHVwidyAVtXaEhGkn6PxB+epKrrAa6nE69qA==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-10.0.0.tgz",
+      "integrity": "sha512-KubSoEAJO+77KPSSWjoLCz0+MIWVNq3joGTSyxucAZrBSJD64Y1O4BHHr1aj6XHIZwXhWWNScQlrQR3OcIulng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-performance-monitor": "9.8.0",
-        "@cspell/cspell-pipe": "9.8.0",
-        "@cspell/cspell-types": "9.8.0",
-        "cspell-trie-lib": "9.8.0",
+        "@cspell/cspell-performance-monitor": "10.0.0",
+        "@cspell/cspell-pipe": "10.0.0",
+        "@cspell/cspell-types": "10.0.0",
+        "cspell-trie-lib": "10.0.0",
         "fast-equals": "^6.0.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/cspell-gitignore": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-9.8.0.tgz",
-      "integrity": "sha512-SDUa1DmSfT20+JH7XtyzcEL9KfurneoR/XbmlrtPQZP/LUHXh3yz4x/0vFIkEFXNWdSckY0QdWTz8DaxClCf4Q==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-10.0.0.tgz",
+      "integrity": "sha512-55XLH9Y52eR7QgyV28Uaw8V9cN1YZ3PQIyrN9YBR4ndQNBKJxO9+jX1nwSspwnccCZiE/N+GGxFzRBb75JDSCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/url": "9.8.0",
-        "cspell-glob": "9.8.0",
-        "cspell-io": "9.8.0"
+        "@cspell/url": "10.0.0",
+        "cspell-glob": "10.0.0",
+        "cspell-io": "10.0.0"
       },
       "bin": {
         "cspell-gitignore": "bin.mjs"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/cspell-glob": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-9.8.0.tgz",
-      "integrity": "sha512-Uvj/iHXs+jpsJyIEnhEoJTWXb1GVyZ9T05L5JFtZfsQNXrh8SRDQPscjxbg4okKr63N7WevfioQum/snHNYvmw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-10.0.0.tgz",
+      "integrity": "sha512-bXS35fMcA9X7GEkfnWBfoPd/vTnxxfXW+YHt6tWxu5fejfs00qUbjWp1oLC9FxRaXWxIkfsYp2mi1k1jYl4RVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/url": "9.8.0",
+        "@cspell/url": "10.0.0",
         "picomatch": "^4.0.4"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/cspell-grammar": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-9.8.0.tgz",
-      "integrity": "sha512-01XMq2vhPS0Gvxnfed9uvOwH+3cXddHYxW0PwCE+SZdcC6TN8yM6glByuLt1qFustAmQVE5GSr7uAY9o4pZQRg==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-10.0.0.tgz",
+      "integrity": "sha512-49udtYzkcCYEIDJbFOb4IwiAJebOYZnYvG6o6Ep19Tq0Xwjk7i4vxUprNiFNDCWFbcbJRPE9cpwQUVwp5WFGLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-pipe": "9.8.0",
-        "@cspell/cspell-types": "9.8.0"
+        "@cspell/cspell-pipe": "10.0.0",
+        "@cspell/cspell-types": "10.0.0"
       },
       "bin": {
         "cspell-grammar": "bin.mjs"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/cspell-io": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-9.8.0.tgz",
-      "integrity": "sha512-JINaEWQEzR4f2upwdZOFcft+nBvQgizJfrOLszxG3p+BIzljnGklqE/nUtLFZpBu0oMJvuM/Fd+GsWor0yP7Xw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-10.0.0.tgz",
+      "integrity": "sha512-NQCAUhx9DwKApxPuFl7EK1K1XSaQEAPld45yjjwv93xF8rJkEGkgzOwjbqafwAD20eKYv1a7oj/9EC0S5jETSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-service-bus": "9.8.0",
-        "@cspell/url": "9.8.0"
+        "@cspell/cspell-service-bus": "10.0.0",
+        "@cspell/url": "10.0.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/cspell-lib": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-9.8.0.tgz",
-      "integrity": "sha512-G2TtPcye5QE5ev3YgWq42UOJLpTZ6naO/47oIm+jmeSYbgnbcOSThnEE7uMycx+TTNOz/vJVFpZmQyt0bWCftw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-10.0.0.tgz",
+      "integrity": "sha512-PowW6JEjuv/F2aFEirZvBxpzHdchOnpsUJbeIcFcai0++taLTbHQObROBEBf7e0S8DnHpVD5TZkqrTME5e44wg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-bundled-dicts": "9.8.0",
-        "@cspell/cspell-performance-monitor": "9.8.0",
-        "@cspell/cspell-pipe": "9.8.0",
-        "@cspell/cspell-resolver": "9.8.0",
-        "@cspell/cspell-types": "9.8.0",
-        "@cspell/dynamic-import": "9.8.0",
-        "@cspell/filetypes": "9.8.0",
-        "@cspell/rpc": "9.8.0",
-        "@cspell/strong-weak-map": "9.8.0",
-        "@cspell/url": "9.8.0",
-        "clear-module": "^4.1.2",
-        "cspell-config-lib": "9.8.0",
-        "cspell-dictionary": "9.8.0",
-        "cspell-glob": "9.8.0",
-        "cspell-grammar": "9.8.0",
-        "cspell-io": "9.8.0",
-        "cspell-trie-lib": "9.8.0",
+        "@cspell/cspell-bundled-dicts": "10.0.0",
+        "@cspell/cspell-performance-monitor": "10.0.0",
+        "@cspell/cspell-pipe": "10.0.0",
+        "@cspell/cspell-resolver": "10.0.0",
+        "@cspell/cspell-types": "10.0.0",
+        "@cspell/dynamic-import": "10.0.0",
+        "@cspell/filetypes": "10.0.0",
+        "@cspell/rpc": "10.0.0",
+        "@cspell/strong-weak-map": "10.0.0",
+        "@cspell/url": "10.0.0",
+        "cspell-config-lib": "10.0.0",
+        "cspell-dictionary": "10.0.0",
+        "cspell-glob": "10.0.0",
+        "cspell-grammar": "10.0.0",
+        "cspell-io": "10.0.0",
+        "cspell-trie-lib": "10.0.0",
         "env-paths": "^4.0.0",
         "gensequence": "^8.0.8",
-        "import-fresh": "^3.3.1",
+        "import-fresh": "^4.0.0",
         "resolve-from": "^5.0.0",
         "vscode-languageserver-textdocument": "^1.0.12",
         "vscode-uri": "^3.1.0",
         "xdg-basedir": "^5.1.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.18.0"
       }
     },
-    "node_modules/cspell-trie-lib": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-9.8.0.tgz",
-      "integrity": "sha512-GXIyqxya8QLp6SjKsAN9w3apvt1Ww7GKcZvTBaP76OfLoyb1QC6unwmObY2cZs1manCntGwHrgU6vFNuXnTzpw==",
+    "node_modules/cspell-lib/node_modules/import-fresh": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-4.0.0.tgz",
+      "integrity": "sha512-Fpi660c7VPDM3fPKYovStd9IP1CPOikf6v/dGxJJMmHPcwYQIMJ4W7kO1avBYEpMqkCh+Dx3Ln6H7VYqgztLjw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.15"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cspell-trie-lib": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-10.0.0.tgz",
+      "integrity": "sha512-R8qrMx10E/bm3Lecslwxn9XYo5NzSRK1rtandEX5n9UmEYHoBXjZELkg5+TOnV8VgrVaJSK57XtcGrbKp/4kSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.18.0"
       },
       "peerDependencies": {
-        "@cspell/cspell-types": "9.8.0"
+        "@cspell/cspell-types": "10.0.0"
       }
     },
     "node_modules/css-select": {
@@ -10253,19 +10248,6 @@
       "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
       "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
       "license": "MIT"
-    },
-    "node_modules/parent-module": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-2.0.0.tgz",
-      "integrity": "sha512-uo0Z9JJeWzv8BG+tRcapBKNJ0dro9cLyczGzulS6EfeyAdeC9sbojtW6XwvYxJkEne9En+J2XEl4zyglVeIwFg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "callsites": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/parse-entities": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@cspell/dict-npm": "^5.2.38",
     "@cspell/dict-typescript": "^3.2.3",
     "@playwright/test": "^1.59.1",
-    "cspell": "^9.8.0",
+    "cspell": "^10.0.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "markdownlint-cli2": "^0.22.0",
     "prettier": "^3.8.3"


### PR DESCRIPTION
## Summary
- Bump `cspell` from `^9.8.0` to `^10.0.0` (and regenerate the lockfile).
- Bump the CI `node-version` in `.github/workflows/build.yml` from `20` to `22`, since cspell 10 requires Node ≥ 22.18.
- No config changes: `cspell.json` and the `@cspell/dict-*` packages are unchanged and remain compatible; both `npm run spellcheck` and `npm run spellcheck:html` pass locally.

## Test plan
- [ ] CI (build workflow) passes on Node 22
- [ ] Source spell check step passes
- [ ] HTML spell check step passes