### PR TITLE
Align @types/node with Node 24 engines constraint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,10 +44,13 @@
         "@cspell/dict-npm": "^5.2.38",
         "@cspell/dict-typescript": "^3.2.3",
         "@playwright/test": "^1.59.1",
-        "@types/node": "^22.19.17",
+        "@types/node": "^24.12.2",
         "cspell": "^10.0.0",
         "markdownlint-cli2": "^0.22.0",
         "prettier": "^3.8.3"
+      },
+      "engines": {
+        "node": ">=24.0.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -3360,12 +3363,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.19.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
-      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/react": {
@@ -10045,21 +10048,6 @@
         "npm": ">=10.8.2"
       }
     },
-    "node_modules/sitemap/node_modules/@types/node": {
-      "version": "24.12.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
-      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~7.16.0"
-      }
-    },
-    "node_modules/sitemap/node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "license": "MIT"
-    },
     "node_modules/slash": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
@@ -10628,9 +10616,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@cspell/dict-npm": "^5.2.38",
     "@cspell/dict-typescript": "^3.2.3",
     "@playwright/test": "^1.59.1",
-    "@types/node": "^22.19.17",
+    "@types/node": "^24.12.2",
     "cspell": "^10.0.0",
     "markdownlint-cli2": "^0.22.0",
     "prettier": "^3.8.3"


### PR DESCRIPTION
## Summary
- Bumps `@types/node` from `^22.19.17` to `^24.12.2` so devDependencies match the `engines: node >=24.0.0` constraint set in #41.
- Addresses PR feedback: eliminates the types/runtime mismatch so any future use of Node 24-specific APIs in build scripts gets correctly typed.

## Test plan
- [x] `npm install` succeeds
- [x] `just validate` passes (lint, spellcheck, build, HTML spellcheck, link validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)