### PR TITLE
Document why baseUrl is omitted in tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,9 +5,8 @@
     "types": [
       "astro/client"
     ],
-    // baseUrl is intentionally omitted: TypeScript 5.5+ permits `paths` without
-    // `baseUrl` under `moduleResolution: "bundler"` (set by astro/tsconfigs/strict).
-    // Path values resolve relative to this tsconfig.json.
+    // baseUrl is intentionally omitted: under `moduleResolution: "bundler"` (set by
+    // astro/tsconfigs/strict), `paths` entries resolve relative to this tsconfig.json.
     "paths": {
       "@*": [
         "./src/*"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,9 @@
     "types": [
       "astro/client"
     ],
+    // baseUrl is intentionally omitted: TypeScript 5.5+ permits `paths` without
+    // `baseUrl` under `moduleResolution: "bundler"` (set by astro/tsconfigs/strict).
+    // Path values resolve relative to this tsconfig.json.
     "paths": {
       "@*": [
         "./src/*"


### PR DESCRIPTION
## Summary
- Add an inline comment explaining that `baseUrl` is intentionally omitted: TypeScript 5.5+ permits `paths` without `baseUrl` under `moduleResolution: "bundler"` (inherited from `astro/tsconfigs/strict`), and path values resolve relative to the tsconfig itself.

Addresses PR feedback requesting documentation of why the `baseUrl` removal is safe, to avoid confusing readers who may copy this config into a TS 4.x project.

## Test plan
- [x] `just build` succeeds