### PR TITLE
Clarify tsconfig.playwright.json types and harden typecheck:app

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev:network": "astro dev --host",
     "build": "astro check && astro build",
     "typecheck": "npm run typecheck:app && npm run typecheck:playwright",
-    "typecheck:app": "tsc -p tsconfig.json --noEmit",
+    "typecheck:app": "astro sync && tsc -p tsconfig.json --noEmit",
     "typecheck:playwright": "tsc -p tsconfig.playwright.json --noEmit",
     "preview": "astro preview",
     "preview:network": "astro preview --host",

--- a/tsconfig.playwright.json
+++ b/tsconfig.playwright.json
@@ -1,6 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // `types` replaces (not merges) the parent array; `astro/client` is
+    // intentionally dropped because Playwright tests don't need it.
     "types": [
       "node",
       "@playwright/test"


### PR DESCRIPTION
## Summary
- Document in `tsconfig.playwright.json` that the `types` array intentionally replaces (not merges) the parent's `astro/client` entry. Playwright tests don't need Astro's ambient types, so dropping it is deliberate.
- Update `typecheck:app` to run `astro sync` before `tsc`, ensuring `.astro/types.d.ts` exists. Without it, `getCollection` resolves to a loose return type and unrelated callsites (e.g. `src/pages/rss.xml.ts`) surface implicit `any` errors on filter callbacks.

## Context
Follow-up to PR feedback on the original tsconfig.playwright.json change:
> When you specify types in a child tsconfig, it replaces (not merges) the parent types array... it's worth verifying tsc -p tsconfig.playwright.json --noEmit passes clean.

Verified clean. The comment makes the intent explicit so future readers don't second-guess it. The `typecheck:app` change resolves the implicit-any errors that surfaced from a cold `.astro/` state.

## Test plan
- [x] `rm -rf .astro && npm run typecheck` passes both `typecheck:app` and `typecheck:playwright` from a cold state
- [x] `npm run typecheck:playwright` continues to pass on its own

🤖 Generated with [Claude Code](https://claude.com/claude-code)